### PR TITLE
Renamed requester to requester_name

### DIFF
--- a/src/main/java/com/redhat/management/approval/Request.java
+++ b/src/main/java/com/redhat/management/approval/Request.java
@@ -29,7 +29,7 @@ public class Request implements Serializable {
     private User user;
     
     public Request(Map<String, Object> maps) {
-        this.requester = maps.get("requester").toString();
+        this.requester = maps.get("requester_name").toString();
         this.id = maps.get("id").toString();
         this.tenantId = maps.get("tenant_id").toString();
         this.name = maps.get("name").toString();

--- a/src/test/java/com/redhat/management/approval/TestResources.java
+++ b/src/test/java/com/redhat/management/approval/TestResources.java
@@ -34,7 +34,7 @@ public class TestResources {
 
         LinkedHashMap<String, Object> rawRequest = new LinkedHashMap();
         rawRequest.put("name", REQUEST_NAME);
-        rawRequest.put("requester", REQUESTER);
+        rawRequest.put("requester_name", REQUESTER);
         rawRequest.put("id", ID);
         rawRequest.put("tenant_id", TENANT_ID);
         rawRequest.put("created_at", CREATED_AT);


### PR DESCRIPTION
Changed to use renamed `requester_name` attribute